### PR TITLE
Rename Package to bwutil

### DIFF
--- a/if.go
+++ b/if.go
@@ -1,4 +1,4 @@
-package util
+package bwutil
 
 func If[T any](check bool, t, f T) (v T) {
 	v = f

--- a/if_test.go
+++ b/if_test.go
@@ -1,4 +1,4 @@
-package util_test
+package bwutil_test
 
 import (
 	"github.com/bradfordwagner/go-util"
@@ -9,12 +9,12 @@ import (
 var _ = Describe("If", func() {
 	It("true, returns first value", func() {
 		a, b := 1, 2
-		res := util.If(true, a, b)
+		res := bwutil.If(true, a, b)
 		Expect(res).To(Equal(a))
 	})
 	It("false, returns second value", func() {
 		a, b := 1, 2
-		res := util.If(false, a, b)
+		res := bwutil.If(false, a, b)
 		Expect(res).To(Equal(b))
 	})
 })

--- a/map.go
+++ b/map.go
@@ -1,4 +1,4 @@
-package util
+package bwutil
 
 // MapCopy - duplicate a map into a new one
 func MapCopy[k comparable, v any](m map[k]v) (res map[k]v) {

--- a/map_test.go
+++ b/map_test.go
@@ -1,4 +1,4 @@
-package util_test
+package bwutil_test
 
 import (
 	"github.com/bradfordwagner/go-util"
@@ -15,7 +15,7 @@ var _ = Describe("Map", func() {
 				1: 1,
 				2: 2,
 			}
-			cp := util.MapCopy(orig)
+			cp := bwutil.MapCopy(orig)
 			Expect(reflect.DeepEqual(orig, cp)).To(BeTrue())
 
 			// altering the cp doesn't affect the orig

--- a/pointer.go
+++ b/pointer.go
@@ -1,4 +1,4 @@
-package util
+package bwutil
 
 // Pointer - returns a pointer version of any object
 func Pointer[T any](t T) *T {

--- a/pointer_test.go
+++ b/pointer_test.go
@@ -1,4 +1,4 @@
-package util_test
+package bwutil_test
 
 import (
 	"github.com/bradfordwagner/go-util"
@@ -9,12 +9,12 @@ import (
 var _ = Describe("Pointer", func() {
 	It("strings", func() {
 		v := "hi friends"
-		p := util.Pointer(v)
+		p := bwutil.Pointer(v)
 		Expect(*p).To(Equal(v))
 	})
 	It("ints", func() {
 		v := 1234
-		p := util.Pointer(v)
+		p := bwutil.Pointer(v)
 		Expect(*p).To(Equal(v))
 	})
 })

--- a/template_suite_test.go
+++ b/template_suite_test.go
@@ -1,4 +1,4 @@
-package util
+package bwutil
 
 import (
 	"testing"


### PR DESCRIPTION
> Don’t steal good names from the user. Avoid giving a package a name that is commonly used in client code. For example, the buffered I/O package is called bufio, not buf, since buf is a good variable name for a buffer.

Avoid taking a common name from the downstream user.